### PR TITLE
to be able to add classes and children classes on template who are extending knp_menu.html.twig

### DIFF
--- a/Resources/views/Menu/knp_menu.html.twig
+++ b/Resources/views/Menu/knp_menu.html.twig
@@ -15,7 +15,10 @@
 {% block item %}
 {% if item.displayed %}
 {# building the class of the item #}
-    {%- set classes = item.attribute('class') is not empty ? [item.attribute('class')] : [] %}
+    {%- set classes = defaultClasses|default([]) %}
+    {%- if item.attribute('class') is not empty %}
+      {%- set classes = classes|merge([item.attribute('class')]) %}
+    {%- endif %}
     {%- if matcher.isCurrent(item) %}
         {%- set classes = classes|merge(['active']) %}
     {%- elseif matcher.isAncestor(item, options.depth) %}
@@ -40,7 +43,10 @@
         {{ block('spanElement') }}
         {%- endif %}
 {# render the list of children#}
-        {%- set childrenClasses = item.childrenAttribute('class') is not empty ? [item.childrenAttribute('class')] : [] %}
+        {%- set childrenClasses = defaultChildrenClasses|default([]) %}
+        {%- if item.childrenAttribute('class') is not empty %}
+          {%- set childrenClasses = childrenClasses|merge([item.childrenAttribute('class')]) %}
+        {%- endif %}
         {%- set childrenClasses = childrenClasses|merge(['menu_level_' ~ item.level]) %}
         {%- set listAttributes = item.childrenAttributes|merge({'class': childrenClasses|join(' ') }) %}
         {{ block('list') }}


### PR DESCRIPTION
Why are we forced to set CSS classes in Menu Builder class ?!
