### PR TITLE
Update knp_menu.html.twig

### DIFF
--- a/Resources/views/Menu/knp_menu.html.twig
+++ b/Resources/views/Menu/knp_menu.html.twig
@@ -21,7 +21,7 @@
     {%- endif %}
     {%- if matcher.isCurrent(item) %}
         {%- set classes = classes|merge(['active']) %}
-    {%- elseif matcher.isAncestor(item, options.depth) %}
+    {%- elseif matcher.isAncestor(item, options.matchingDepth) %}
         {%- set classes = classes|merge([options.ancestorClass]) %}
     {%- endif %}
     {%- if item.actsLikeFirst %}


### PR DESCRIPTION
use "matchingDepth" instead of "depth" to match ancestor : could be able to determine ancestor even if menu item isn't show (hidden by depth)
